### PR TITLE
feat(bench): add MVP benchmark suite with orders, comparison, and min…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,168 +1,153 @@
 # AGENTS.md
 
-Repository playbook for agentic coding tools working in `ContextFS`.
-This document is evidence-based from current repo files and scripts.
+Repository playbook for coding agents working in `D:\code\python_code\ContextFS`.
+All commands and conventions below are evidence-based from current repo files.
 
-## Repository Scope
+## 1) Repository Map
 
-- Primary runtime code: `.opencode/plugins/contextfs/src/*.mjs`
+- Core plugin runtime: `.opencode/plugins/contextfs/src/*.mjs`
 - Plugin entry: `.opencode/plugins/contextfs.plugin.mjs`
 - CLI entry: `.opencode/plugins/contextfs/cli.mjs`
 - Tool bridge: `.opencode/tools/contextfs.ts`
-- Unit tests: `.opencode/plugins/contextfs/test/contextfs.test.mjs`
-- Regression suite: `scripts/regression-contextfs.mjs`
+- Plugin unit tests: `.opencode/plugins/contextfs/test/contextfs.test.mjs`
+- Regression script: `scripts/regression-contextfs.mjs`
+- Benchmark scripts: `bench/*.mjs`
+- Benchmark tests: `bench/bench.test.mjs`
 
-## Environment and Module System
+## 2) Module / Runtime Facts
 
-- Node.js ESM is used for plugin/runtime JS (`"type": "module"` in `.opencode/plugins/contextfs/package.json`).
-- Source files use `.mjs` modules with named exports.
-- TypeScript appears only in the tool bridge (`.opencode/tools/contextfs.ts`).
+- Plugin package is ESM (`"type": "module"` in `.opencode/plugins/contextfs/package.json`).
+- Runtime code is plain JS `.mjs`; no compile/build step is required.
+- TypeScript is only used in the tool bridge (`.opencode/tools/contextfs.ts`).
 
-## Source of Truth for Commands
+## 3) Authoritative Command Sources
 
 - Root scripts: `package.json`
 - Plugin scripts: `.opencode/plugins/contextfs/package.json`
-- Command docs: `README.md` and `.opencode/plugins/contextfs/README.md`
+- User docs: `README.md`, `.opencode/plugins/contextfs/README.md`
 
-## Build / Lint / Test Commands
+## 4) Build / Lint / Test / Benchmark Commands
 
 ### Install
 
-- Root dependencies (if needed by your environment): `npm install`
-- Plugin-local tests do not require a bundler.
+- `npm install` (root)
+- `npm install --prefix .opencode/plugins/contextfs` (plugin-local if needed)
 
 ### Build
 
-- No dedicated build script exists in root `package.json`.
-- No transpilation step is required for `.mjs` runtime code.
+- No build script exists in root `package.json`.
+- No transpilation pipeline exists for plugin runtime.
 
 ### Lint / Format
 
-- No lint script is currently defined.
-- No formatter config (Prettier/Biome/ESLint config) is present.
-- Follow existing style in source files instead of introducing new style systems.
+- No lint script is defined.
+- No ESLint/Prettier/Biome config is present.
+- Follow existing in-file style; do not introduce a new formatter/linter setup unless requested.
 
-### Test (Full)
+### Tests (full)
 
-- Root unit entry: `npm run test:contextfs:unit`
-- Root regression entry: `npm run test:contextfs:regression`
-- Plugin-local unit entry: `npm test --prefix .opencode/plugins/contextfs`
+- Root unit tests: `npm run test:contextfs:unit`
+- Root regression tests: `npm run test:contextfs:regression`
+- Plugin-local tests: `npm test --prefix .opencode/plugins/contextfs`
+- Benchmark tests: `node --test bench/bench.test.mjs`
 
-### Test (Single Test)
+### Tests (single test)
 
-- Single test by name (from repo root):
+- Single plugin test (from repo root):
   - `node --test --test-name-pattern="appendHistory handles 15 concurrent writes" ./.opencode/plugins/contextfs/test/contextfs.test.mjs`
-- Single test by name (from plugin dir):
+- Single benchmark test (from repo root):
+  - `node --test --test-name-pattern="timing fields are sane in jsonl outputs" ./bench/bench.test.mjs`
+- Single plugin test (from plugin directory):
   - `node --test --test-name-pattern="writeText waits for lock release and retries" ./test/contextfs.test.mjs`
-- Note: there is no dedicated npm alias for single-test runs yet.
 
-### Run Regression Script Directly
+### Benchmark runs
 
-- `node scripts/regression-contextfs.mjs`
-- This runs TEST-1..TEST-6 sequentially and prints table + JSON summary.
+- ContextFS E2E: `npm run bench:e2e -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42`
+- Naive baseline: `npm run bench:naive -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42`
+- Compare AB only: `npm run bench -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42 --orders 1`
+- Compare AB+BA: `npm run bench -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42 --orders 2`
 
-## Manual Runtime Validation Commands
+### CLI sanity checks
 
 - `node .opencode/plugins/contextfs/cli.mjs ls`
 - `node .opencode/plugins/contextfs/cli.mjs pin "must keep scope small"`
 - `node .opencode/plugins/contextfs/cli.mjs compact`
 - `node .opencode/plugins/contextfs/cli.mjs pack`
 
-## Cursor / Copilot Rules
+## 5) Cursor / Copilot Rules
 
-- `.cursorrules`: not found.
-- `.cursor/rules/`: not found.
-- `.github/copilot-instructions.md`: not found.
-- If these are added later, update this file and treat them as highest-priority local policy.
+- `.cursorrules`: not found
+- `.cursor/rules/`: not found
+- `.github/copilot-instructions.md`: not found
 
-## Code Style Conventions (Observed)
+If any of these files are later added, treat them as higher-priority local policy and update this file.
 
-### Imports and Modules
+## 6) Code Style Guidelines (Observed in Current Code)
+
+### Imports
 
 - Use ESM imports with double quotes.
-- Node built-ins are imported via `node:` specifiers (for example `node:fs/promises`, `node:path`).
-- Typical import order is:
-  1) Node built-ins
-  2) local project modules
-  3) blank line between groups
-- Prefer named imports for local modules; default imports used for Node APIs when appropriate.
-
-### Naming
-
-- Functions/variables: `camelCase` (`safeTrim`, `mergeConfig`, `maybeCompact`).
-- Classes: `PascalCase` (`ContextFsStorage`).
-- Constants: `UPPER_SNAKE_CASE` for module-level fixed values (`DEFAULT_CONFIG`, `FILES`, regex constants).
-- Test names are descriptive sentence strings in `test("...", ...)`.
+- Import Node built-ins via `node:` specifiers.
+- Keep imports grouped: built-ins first, then local modules, with a blank line between groups.
 
 ### Formatting
 
-- Semicolons are used consistently.
-- Two-space indentation.
-- Trailing commas are used in multiline arrays/objects/args.
-- Keep helpers small and focused.
-- Prefer early returns to reduce nesting.
+- Use semicolons.
+- Use two-space indentation.
+- Use trailing commas in multiline objects/arrays/calls.
+- Prefer short helpers and early returns to reduce nesting.
 
-### Strings
+### Naming
 
-- Prefer template literals for composed output.
-- Keep user-facing command output human-readable and line-oriented.
-- Use explicit section markers in generated context blocks.
+- Variables/functions: `camelCase` (`mergeConfig`, `maybeCompact`, `safeTrim`).
+- Classes: `PascalCase` (`ContextFsStorage`).
+- Constants: `UPPER_SNAKE_CASE` for module-level fixed values (`DEFAULT_CONFIG`, `FILES`).
+- Tests: descriptive sentence-style names in `test("...", ...)`.
 
-### Types and Type Safety
+### Strings and output
 
-- JS runtime code is untyped but intentionally strict about normalization (`String(...)`, `Number(...)`).
-- TS bridge keeps explicit argument typing for subprocess wrappers.
-- Do not add `any`-style escapes in TS unless absolutely unavoidable.
+- Prefer template literals for assembled text.
+- Keep CLI/script output line-oriented and readable.
+- For persisted markdown/json content, keep stable headers and newline conventions.
 
-### Async and Concurrency
+### Types and validation
 
-- Use `async/await` over raw promise chains.
-- Critical storage writes are lock-protected (`acquireLock` / `releaseLock`).
-- Atomic write pattern is `write temp -> rename`.
-- For concurrent tests, use `Promise.allSettled` and assert `rejected === 0` plus file parse integrity.
+- Runtime JS code normalizes inputs explicitly (`String(...)`, `Number(...)`, clamping helpers).
+- In TS bridge, keep strict argument typing; avoid `any`-style escapes unless absolutely necessary.
 
-### Error Handling
+### Async / concurrency / I/O
 
-- Throw explicit errors for hard failures (for example lock timeout).
-- Use narrow `try/catch` for best-effort cleanup (unlink temp files, lock release).
-- Avoid swallowing errors unless operation is explicitly optional/cleanup-only.
-- CLI/process entrypoints set `process.exitCode` and print stack/message to stderr on failure.
-
-### Data and File IO
-
-- Runtime state is under `.contextfs/` (or configured dir).
+- Prefer `async/await` over promise chains.
+- Storage writes are lock-aware (`acquireLock` / `releaseLock`).
+- Use atomic write pattern (`write temp -> rename`) where implemented.
 - History is NDJSON (`history.ndjson`), one JSON object per line.
-- State file is formatted JSON with trailing newline.
-- Manifest/pins/summary are markdown text files with stable headers.
 
-### Testing Style
+### Error handling
 
-- Use Node built-in test runner (`node:test`) + `node:assert/strict`.
-- Test behavior, not implementation details.
-- For filesystem tests, create isolated temp directories and clean up in `finally`.
-- Concurrency tests must validate:
-  - rejected writes count
-  - line count expectations
-  - JSON parseability of each line
+- Throw explicit errors for hard failures (example: lock timeout).
+- Use narrow `try/finally` for lock release and cleanup.
+- Do not silently swallow non-optional errors.
+- CLI entrypoints should print errors to stderr and set `process.exitCode = 1`.
 
-## Implementation Guardrails for Agents
+### Test style
 
-- Keep changes minimal and local; avoid architecture rewrites.
-- Match existing file layout and naming before introducing new modules.
-- Prefer adding focused tests when changing storage/concurrency behavior.
-- Do not silently change config semantics; document user-facing behavior in README.
-- If changing command outputs, keep machine- and human-readable patterns stable.
+- Use Node test runner: `node:test` + `node:assert/strict`.
+- Create temp dirs for filesystem tests and always clean up in `finally`.
+- For concurrency tests, verify both success counts and file integrity/parsability.
+- For schema tests, compare nested key/type parity and check timing invariants explicitly.
 
-## Known Gaps (Current Repo State)
+## 7) Agent Guardrails for This Repo
 
-- No linting pipeline configured.
-- No formal CI workflow committed yet.
-- No single-test npm convenience script (use `node --test --test-name-pattern`).
+- Keep changes focused and minimal; avoid broad refactors unless requested.
+- Match existing `.mjs` patterns before introducing new abstractions.
+- If storage/compaction behavior changes, run both unit and regression tests.
+- If benchmark behavior changes, run `node --test bench/bench.test.mjs` and at least one `npm run bench ...` command.
+- Update `README.md` when user-facing commands/outputs change.
 
-## Fast Path Checklist for Agents
+## 8) Quick Execution Checklist
 
-1) Read `package.json` and `.opencode/plugins/contextfs/package.json` first.
-2) Run `npm run test:contextfs:unit` before and after code edits.
-3) If storage logic changed, run `npm run test:contextfs:regression`.
-4) Update `README.md` and/or `.opencode/plugins/contextfs/README.md` when behavior changes.
-5) Keep this `AGENTS.md` in sync with real commands and conventions.
+1. Read `package.json` and `.opencode/plugins/contextfs/package.json` first.
+2. Run `npm run test:contextfs:unit` before/after core changes.
+3. Run `npm run test:contextfs:regression` after storage/compaction changes.
+4. Run benchmark tests if touching `bench/*`.
+5. Keep this `AGENTS.md` aligned with actual scripts and behavior.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,43 @@ npm run test:contextfs:unit
 npm run test:contextfs:regression
 ```
 
+## Benchmark
+
+用于看三件事：
+- token 增长（ContextFS 是否进入平台期，naive 是否线性上升）
+- 每轮延迟（`turn_time p95`）
+- 压缩触发频率（`compact_count`）
+
+### 运行指令
+
+```bash
+# ContextFS E2E
+npm run bench:e2e -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42
+
+# naive baseline
+npm run bench:naive -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42
+
+# 对比：只跑 AB（contextfs->naive）
+npm run bench -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42 --orders 1
+
+# 对比：跑 AB+BA（输出跨顺序中位结果）
+npm run bench -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42 --orders 2
+```
+
+### 指标含义
+
+- `pack_tokens max/p95`：pack token 规模上界和尾部水平
+- `turn_time p95(ms)`：每轮耗时的 95 分位
+- `compact_count`：压缩触发次数
+- `total_elapsed_ms`：整次 benchmark 总耗时
+
+### 目前效果（turns=3000, avgChars=400, variance=0.6, seed=42）
+
+| Mode | pack_tokens max/p95 (ContextFS vs Naive) | turn_time p95(ms) (ContextFS vs Naive) | compact_count (ContextFS vs Naive) | total_elapsed_ms (ContextFS vs Naive) |
+|---|---|---|---|---|
+| orders=1 | 1895 / 1714 vs 312204 / 296535 | 37.074 vs 43.512 | 46 vs 0 | 67708.688 vs 75457.429 |
+| orders=2 | 1895 / 1714 vs 312204 / 296535 | 38.154 vs 62.213 | 46 vs 0 | 63816.747 vs 90239.452 |
+
 ## 技术亮点
 
 - **配置验证**：所有配置项都有范围限制和类型归一化
@@ -116,7 +153,3 @@ npm run test:contextfs:regression
 - 无 UI 面板
 
 专注于解决"长会话上下文爆炸"这一具体问题。
-
-## 许可证
-
-MIT

--- a/bench/bench.mjs
+++ b/bench/bench.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { runContextFsBenchmark } from "./bench_e2e.mjs";
+import { runNaiveBenchmark } from "./bench_naive.mjs";
+import { parseBenchArgs } from "./lib/synth.mjs";
+import { detectPlateauTurn, linearSlope, median, percentile, toFixed3 } from "./lib/stats.mjs";
+
+function buildComparison(contextfs, naive) {
+  const ctxSeries = contextfs.token_series_post_compact;
+  const naiveSeries = naive.token_series_post_compact;
+  const ctxSlope = linearSlope(ctxSeries);
+  const naiveSlope = linearSlope(naiveSeries);
+  const plateauTurn = detectPlateauTurn(ctxSeries);
+
+  return {
+    pack_tokens: {
+      contextfs: {
+        max: toFixed3(contextfs.pack_tokens.max),
+        p95: toFixed3(percentile(ctxSeries, 95)),
+      },
+      naive: {
+        max: toFixed3(naive.pack_tokens.max),
+        p95: toFixed3(percentile(naiveSeries, 95)),
+      },
+    },
+    turn_time: {
+      contextfs_p95: toFixed3(contextfs.turn_time.p95),
+      naive_p95: toFixed3(naive.turn_time.p95),
+    },
+    compact_count: {
+      contextfs: contextfs.compact_count,
+      naive: naive.compact_count,
+    },
+    total_elapsed_ms: {
+      contextfs: toFixed3(contextfs.total_elapsed_ms),
+      naive: toFixed3(naive.total_elapsed_ms),
+      combined: toFixed3(contextfs.total_elapsed_ms + naive.total_elapsed_ms),
+    },
+    assertions: {
+      naive_linear_growth: naiveSlope > 0,
+      contextfs_plateau: plateauTurn > 0,
+      slope_contextfs: toFixed3(ctxSlope),
+      slope_naive: toFixed3(naiveSlope),
+      plateau_turn: plateauTurn,
+      no_lock_residue: !contextfs.lock_file_exists && !naive.lock_file_exists,
+    },
+  };
+}
+
+function medianComparison(comparisons) {
+  const ctxPackMax = comparisons.map((x) => x.pack_tokens.contextfs.max);
+  const naivePackMax = comparisons.map((x) => x.pack_tokens.naive.max);
+  const ctxPackP95 = comparisons.map((x) => x.pack_tokens.contextfs.p95);
+  const naivePackP95 = comparisons.map((x) => x.pack_tokens.naive.p95);
+  const ctxTurnP95 = comparisons.map((x) => x.turn_time.contextfs_p95);
+  const naiveTurnP95 = comparisons.map((x) => x.turn_time.naive_p95);
+  const ctxCompactCount = comparisons.map((x) => x.compact_count.contextfs);
+  const naiveCompactCount = comparisons.map((x) => x.compact_count.naive);
+  const ctxElapsed = comparisons.map((x) => x.total_elapsed_ms.contextfs);
+  const naiveElapsed = comparisons.map((x) => x.total_elapsed_ms.naive);
+  const combinedElapsed = comparisons.map((x) => x.total_elapsed_ms.combined);
+  const slopeCtx = comparisons.map((x) => x.assertions.slope_contextfs);
+  const slopeNaive = comparisons.map((x) => x.assertions.slope_naive);
+  const plateauTurn = comparisons.map((x) => x.assertions.plateau_turn).filter((x) => x > 0);
+
+  return {
+    pack_tokens: {
+      contextfs: { max: toFixed3(median(ctxPackMax)), p95: toFixed3(median(ctxPackP95)) },
+      naive: { max: toFixed3(median(naivePackMax)), p95: toFixed3(median(naivePackP95)) },
+    },
+    turn_time: {
+      contextfs_p95: toFixed3(median(ctxTurnP95)),
+      naive_p95: toFixed3(median(naiveTurnP95)),
+    },
+    compact_count: {
+      contextfs: Math.round(median(ctxCompactCount)),
+      naive: Math.round(median(naiveCompactCount)),
+    },
+    total_elapsed_ms: {
+      contextfs: toFixed3(median(ctxElapsed)),
+      naive: toFixed3(median(naiveElapsed)),
+      combined: toFixed3(median(combinedElapsed)),
+    },
+    assertions: {
+      naive_linear_growth: comparisons.every((x) => x.assertions.naive_linear_growth),
+      contextfs_plateau: comparisons.every((x) => x.assertions.contextfs_plateau),
+      slope_contextfs: toFixed3(median(slopeCtx)),
+      slope_naive: toFixed3(median(slopeNaive)),
+      plateau_turn: plateauTurn.length ? Math.round(median(plateauTurn)) : -1,
+      no_lock_residue: comparisons.every((x) => x.assertions.no_lock_residue),
+    },
+  };
+}
+
+async function runPair(order, params, suffix) {
+  if (order === "contextfs->naive") {
+    const contextfs = await runContextFsBenchmark(params, { suffix });
+    const naive = await runNaiveBenchmark(params, { suffix });
+    return { order, contextfs, naive };
+  }
+  const naive = await runNaiveBenchmark(params, { suffix });
+  const contextfs = await runContextFsBenchmark(params, { suffix });
+  return { order, contextfs, naive };
+}
+
+function printCompare(params, comparison, runOrders) {
+  const strategy = runOrders.length > 1 ? `median(${runOrders.join(", ")})` : runOrders[0];
+  console.log("\n# ContextFS vs Naive\n");
+  console.log(`- turns: ${params.turns}`);
+  console.log(`- avgChars: ${params.avgChars}`);
+  console.log(`- variance: ${params.variance}`);
+  console.log(`- seed: ${params.seed}`);
+  console.log(`- order_strategy: ${strategy}`);
+  console.log("");
+  console.log("| Metric | ContextFS | Naive |");
+  console.log("|---|---:|---:|");
+  console.log(`| pack_tokens max | ${comparison.pack_tokens.contextfs.max} | ${comparison.pack_tokens.naive.max} |`);
+  console.log(`| pack_tokens p95 | ${comparison.pack_tokens.contextfs.p95} | ${comparison.pack_tokens.naive.p95} |`);
+  console.log(`| turn_time p95(ms) | ${comparison.turn_time.contextfs_p95} | ${comparison.turn_time.naive_p95} |`);
+  console.log(`| compact_count | ${comparison.compact_count.contextfs} | ${comparison.compact_count.naive} |`);
+  console.log(`| total_elapsed_ms | ${comparison.total_elapsed_ms.contextfs} | ${comparison.total_elapsed_ms.naive} |`);
+  console.log("");
+  console.log(`- combined_elapsed_ms: ${comparison.total_elapsed_ms.combined}`);
+  console.log(`- naive_linear_growth: ${comparison.assertions.naive_linear_growth}`);
+  console.log(`- contextfs_plateau: ${comparison.assertions.contextfs_plateau}`);
+  console.log(`- slope_naive: ${comparison.assertions.slope_naive}`);
+  console.log(`- slope_contextfs: ${comparison.assertions.slope_contextfs}`);
+  console.log(`- plateau_turn: ${comparison.assertions.plateau_turn}`);
+  console.log(`- no_lock_residue: ${comparison.assertions.no_lock_residue}`);
+}
+
+async function main() {
+  const params = parseBenchArgs(process.argv.slice(2));
+  await fs.mkdir(params.outDir, { recursive: true });
+
+  const runAB = await runPair("contextfs->naive", params, "_ab");
+  const comparisonAB = buildComparison(runAB.contextfs.summary, runAB.naive.summary);
+  let runBA = null;
+  let comparisonBA = null;
+
+  if (params.orders > 1) {
+    runBA = await runPair("naive->contextfs", params, "_ba");
+    comparisonBA = buildComparison(runBA.contextfs.summary, runBA.naive.summary);
+  }
+
+  const comparisons = [comparisonAB, ...(comparisonBA ? [comparisonBA] : [])];
+  const comparison = {
+    median_of_orders: medianComparison(comparisons),
+  };
+
+  const summaryPath = path.join(params.outDir, "bench_summary.json");
+  const summary = {
+    params,
+    orders: {
+      ab: {
+        order: runAB.order,
+        contextfs: runAB.contextfs.summary,
+        naive: runAB.naive.summary,
+        comparison: comparisonAB,
+      },
+      ba: runBA
+        ? {
+            order: runBA.order,
+            contextfs: runBA.contextfs.summary,
+            naive: runBA.naive.summary,
+            comparison: comparisonBA,
+          }
+        : null,
+    },
+    comparison,
+    artifacts: {
+      contextfs_ab: path.join(params.outDir, "bench_results_contextfs_ab.jsonl"),
+      naive_ab: path.join(params.outDir, "bench_results_naive_ab.jsonl"),
+      contextfs_ba: runBA ? path.join(params.outDir, "bench_results_contextfs_ba.jsonl") : null,
+      naive_ba: runBA ? path.join(params.outDir, "bench_results_naive_ba.jsonl") : null,
+      summary: summaryPath,
+    },
+  };
+
+  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  printCompare(params, comparison.median_of_orders, runBA ? [runAB.order, runBA.order] : [runAB.order]);
+  console.log(`\n- summary_file: ${summaryPath}`);
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exitCode = 1;
+});

--- a/bench/bench.test.mjs
+++ b/bench/bench.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { createMulberry32, generateTurn } from "./lib/synth.mjs";
+import { runContextFsBenchmark } from "./bench_e2e.mjs";
+import { runNaiveBenchmark } from "./bench_naive.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function assertSameShape(a, b, prefix = "") {
+  assert.equal(typeof a, typeof b, `type mismatch at ${prefix || "root"}`);
+  if (a == null || b == null) {
+    return;
+  }
+  if (Array.isArray(a)) {
+    assert.ok(Array.isArray(b), `array mismatch at ${prefix || "root"}`);
+    return;
+  }
+  if (typeof a === "object") {
+    const aKeys = Object.keys(a).sort();
+    const bKeys = Object.keys(b).sort();
+    assert.deepEqual(aKeys, bKeys, `key mismatch at ${prefix || "root"}`);
+    for (const key of aKeys) {
+      assertSameShape(a[key], b[key], prefix ? `${prefix}.${key}` : key);
+    }
+  }
+}
+
+test("synth generation is deterministic for same seed", () => {
+  const rngA = createMulberry32(42);
+  const rngB = createMulberry32(42);
+  const seqA = [];
+  const seqB = [];
+  for (let i = 1; i <= 5; i += 1) {
+    seqA.push(generateTurn(i, rngA, 180, 0.4, 42));
+    seqB.push(generateTurn(i, rngB, 180, 0.4, 42));
+  }
+  assert.deepEqual(seqA, seqB);
+});
+
+test("contextfs and naive summaries keep schema parity with nested keys/types", async () => {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "contextfs-bench-test-parity-"));
+  try {
+    const params = {
+      turns: 12,
+      avgChars: 200,
+      variance: 0.3,
+      seed: 7,
+      threshold: 900,
+      recentN: 6,
+      outDir,
+    };
+    const contextfs = await runContextFsBenchmark(params);
+    const naive = await runNaiveBenchmark(params);
+    assertSameShape(contextfs.summary, naive.summary);
+  } finally {
+    await fs.rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("timing fields are sane in jsonl outputs", async () => {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "contextfs-bench-test-timing-"));
+  try {
+    const params = {
+      turns: 10,
+      avgChars: 220,
+      variance: 0.35,
+      seed: 11,
+      threshold: 900,
+      recentN: 6,
+      outDir,
+    };
+
+    await runContextFsBenchmark(params);
+    await runNaiveBenchmark(params);
+
+    for (const fileName of ["bench_results_contextfs.jsonl", "bench_results_naive.jsonl"]) {
+      const raw = await fs.readFile(path.join(outDir, fileName), "utf8");
+      const lines = raw.trim().split("\n");
+      assert.equal(lines.length, params.turns);
+      for (const line of lines) {
+        const row = JSON.parse(line);
+        assert.ok(row.pack_build_time_ms >= 0);
+        assert.ok(row.token_est_time_ms >= 0);
+        assert.ok(row.pack_time_ms >= row.pack_build_time_ms);
+        assert.ok(row.pack_time_ms >= row.token_est_time_ms);
+        assert.ok(Math.abs(row.pack_time_ms - (row.pack_build_time_ms + row.token_est_time_ms)) < 1e-9);
+        assert.ok(row.compact_check_time_ms >= row.compact_total_time_ms);
+      }
+    }
+  } finally {
+    await fs.rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("bench summary keeps orders blocks, median comparison, and row key parity", async () => {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "contextfs-bench-test-orders-"));
+  try {
+    await execFileAsync("node", ["bench/bench.mjs", "--turns", "20", "--avgChars", "220", "--variance", "0.35", "--seed", "11", "--orders", "2", "--outDir", outDir], {
+      cwd: path.join(process.cwd()),
+    });
+
+    const summary = JSON.parse(await fs.readFile(path.join(outDir, "bench_summary.json"), "utf8"));
+    assert.ok(summary.orders?.ab);
+    assert.ok(summary.orders?.ba);
+    assert.ok(summary.comparison?.median_of_orders);
+    assertSameShape(summary.orders.ab.comparison, summary.comparison.median_of_orders);
+    assertSameShape(summary.orders.ba.comparison, summary.comparison.median_of_orders);
+
+    const artifactKeys = Object.keys(summary.artifacts || {}).sort();
+    assert.deepEqual(artifactKeys, [
+      "contextfs_ab",
+      "contextfs_ba",
+      "naive_ab",
+      "naive_ba",
+      "summary",
+    ]);
+
+    const ctxLines = (await fs.readFile(summary.artifacts.contextfs_ab, "utf8")).trim().split("\n");
+    const naiveLines = (await fs.readFile(summary.artifacts.naive_ab, "utf8")).trim().split("\n");
+    const sample = Math.min(5, ctxLines.length, naiveLines.length);
+    for (let i = 0; i < sample; i += 1) {
+      const ctxKeys = Object.keys(JSON.parse(ctxLines[i])).sort();
+      const naiveKeys = Object.keys(JSON.parse(naiveLines[i])).sort();
+      assert.deepEqual(ctxKeys, naiveKeys);
+    }
+  } finally {
+    await fs.rm(outDir, { recursive: true, force: true });
+  }
+});

--- a/bench/bench_e2e.mjs
+++ b/bench/bench_e2e.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+
+import { mergeConfig } from "../.opencode/plugins/contextfs/src/config.mjs";
+import { ContextFsStorage } from "../.opencode/plugins/contextfs/src/storage.mjs";
+import { buildContextPack } from "../.opencode/plugins/contextfs/src/packer.mjs";
+import { maybeCompact } from "../.opencode/plugins/contextfs/src/compactor.mjs";
+import { parseBenchArgs, createMulberry32, generateTurn } from "./lib/synth.mjs";
+import { summarizeSeries, normalizeSummary } from "./lib/stats.mjs";
+
+function buildSummary(params, metrics) {
+  const packTokensPost = normalizeSummary({
+    ...summarizeSeries(metrics.tokenSeriesPost),
+    end: metrics.tokenSeriesPost[metrics.tokenSeriesPost.length - 1] || 0,
+  });
+  return {
+    turns: params.turns,
+    compact_count: metrics.compactCount,
+    total_elapsed_ms: metrics.elapsedMs,
+    lock_file_exists: metrics.lockExists,
+    pack_tokens: packTokensPost,
+    pack_tokens_pre: normalizeSummary({
+      ...summarizeSeries(metrics.tokenSeriesPre),
+      end: metrics.tokenSeriesPre[metrics.tokenSeriesPre.length - 1] || 0,
+    }),
+    pack_tokens_post: packTokensPost,
+    turn_time: normalizeSummary(summarizeSeries(metrics.turnTimes)),
+    pack_time: normalizeSummary(summarizeSeries(metrics.packTimes)),
+    pack_build_time: normalizeSummary(summarizeSeries(metrics.packBuildTimes)),
+    token_est_time: normalizeSummary(summarizeSeries(metrics.tokenEstTimes)),
+    compact_time: normalizeSummary(summarizeSeries(metrics.compactTotalTimes)),
+    compact_check_time: normalizeSummary(summarizeSeries(metrics.compactCheckTimes)),
+    compact_total_time: normalizeSummary(summarizeSeries(metrics.compactTotalTimes)),
+    io_time: normalizeSummary(summarizeSeries(metrics.ioTimes)),
+    token_series_pre_compact: metrics.tokenSeriesPre,
+    token_series_post_compact: metrics.tokenSeriesPost,
+    token_series: metrics.tokenSeriesPost,
+  };
+}
+
+export async function runContextFsBenchmark(params, options = {}) {
+  const suffix = options.suffix || "";
+  const outPath = path.join(params.outDir, `bench_results_contextfs${suffix}.jsonl`);
+  await fs.mkdir(params.outDir, { recursive: true });
+
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "contextfs-bench-e2e-"));
+  const configInput = {
+    autoInject: true,
+    autoCompact: true,
+    contextfsDir: ".contextfs",
+  };
+  if (params.threshold != null) {
+    configInput.tokenThreshold = params.threshold;
+  }
+  if (params.recentN != null) {
+    configInput.recentTurns = params.recentN;
+  }
+  const config = mergeConfig(configInput);
+  const storage = new ContextFsStorage(workspace, config);
+  await storage.ensureInitialized();
+
+  const rng = createMulberry32(params.seed);
+  const lines = [];
+  const turnTimes = [];
+  const packTimes = [];
+  const packBuildTimes = [];
+  const tokenEstTimes = [];
+  const ioTimes = [];
+  const compactCheckTimes = [];
+  const compactTotalTimes = [];
+  const tokenSeriesPre = [];
+  const tokenSeriesPost = [];
+  let compactCount = 0;
+
+  const startedAt = performance.now();
+  try {
+    for (let turn = 1; turn <= params.turns; turn += 1) {
+      const turnStart = performance.now();
+      const event = generateTurn(turn, rng, params.avgChars, params.variance, params.seed);
+
+      const ioStart = performance.now();
+      await storage.appendHistory(event);
+      const ioMs = performance.now() - ioStart;
+
+      const packBuildStart = performance.now();
+      const pack = await buildContextPack(storage, config);
+      const packBuildMs = performance.now() - packBuildStart;
+      const tokenEstMs = 0;
+      const preTokens = pack.details.estimatedTokens;
+
+      const compactCheckStart = performance.now();
+      const compactResult = await maybeCompact(storage, config, false);
+      const compactCheckMs = performance.now() - compactCheckStart;
+
+      const compacted = Boolean(compactResult?.compacted);
+      const compactTotalMs = compactCheckMs;
+      if (compacted) {
+        compactCount += 1;
+      }
+
+      let postTokens = preTokens;
+      if (compacted) {
+        const postPack = await buildContextPack(storage, config);
+        postTokens = postPack.details.estimatedTokens;
+      }
+
+      const packMs = packBuildMs + tokenEstMs;
+      const turnMs = performance.now() - turnStart;
+
+      lines.push(
+        JSON.stringify({
+          turn,
+          pack_build_time_ms: packBuildMs,
+          token_est_time_ms: tokenEstMs,
+          pack_time_ms: packMs,
+          compact_check_time_ms: compactCheckMs,
+          compact_total_time_ms: compactTotalMs,
+          compact_time_ms: compactTotalMs,
+          io_time_ms: ioMs,
+          turn_time_ms: turnMs,
+          pack_est_tokens_pre_compact: preTokens,
+          pack_est_tokens_post_compact: postTokens,
+          pack_est_tokens: postTokens,
+          compacted,
+        }),
+      );
+
+      turnTimes.push(turnMs);
+      packTimes.push(packMs);
+      packBuildTimes.push(packBuildMs);
+      tokenEstTimes.push(tokenEstMs);
+      ioTimes.push(ioMs);
+      compactCheckTimes.push(compactCheckMs);
+      compactTotalTimes.push(compactTotalMs);
+      tokenSeriesPre.push(preTokens);
+      tokenSeriesPost.push(postTokens);
+    }
+
+    await fs.writeFile(outPath, `${lines.join("\n")}\n`, "utf8");
+
+    const lockPath = path.join(workspace, config.contextfsDir, ".lock");
+    let lockExists = false;
+    try {
+      await fs.access(lockPath);
+      lockExists = true;
+    } catch {
+      lockExists = false;
+    }
+
+    const elapsedMs = performance.now() - startedAt;
+    return {
+      label: "contextfs",
+      resultsPath: outPath,
+      summary: buildSummary(params, {
+        compactCount,
+        elapsedMs,
+        lockExists,
+        turnTimes,
+        packTimes,
+        packBuildTimes,
+        tokenEstTimes,
+        ioTimes,
+        compactCheckTimes,
+        compactTotalTimes,
+        tokenSeriesPre,
+        tokenSeriesPost,
+      }),
+    };
+  } finally {
+    await fs.rm(workspace, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const params = parseBenchArgs(process.argv.slice(2));
+  const result = await runContextFsBenchmark(params);
+  console.log("# ContextFS E2E Benchmark Summary");
+  console.log(JSON.stringify({ params, contextfs: result.summary, out: result.resultsPath }, null, 2));
+}
+
+const isMain = process.argv[1] ? pathToFileURL(process.argv[1]).href === import.meta.url : false;
+
+if (isMain) {
+  main().catch((err) => {
+    console.error(err?.stack || String(err));
+    process.exitCode = 1;
+  });
+}

--- a/bench/bench_naive.mjs
+++ b/bench/bench_naive.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+
+import { mergeConfig } from "../.opencode/plugins/contextfs/src/config.mjs";
+import { ContextFsStorage } from "../.opencode/plugins/contextfs/src/storage.mjs";
+import { estimateTokens } from "../.opencode/plugins/contextfs/src/token.mjs";
+import { parseBenchArgs, createMulberry32, generateTurn } from "./lib/synth.mjs";
+import { summarizeSeries, normalizeSummary } from "./lib/stats.mjs";
+
+function buildNaivePack(turns) {
+  const lines = turns.map((item, idx) => `${idx + 1}. [${item.role}] ${item.text}`);
+  return ["<<<NAIVE:BEGIN>>>", "## Naive Full History Pack", ...lines, "<<<NAIVE:END>>>"].join("\n");
+}
+
+function buildSummary(params, metrics) {
+  const packTokensPost = normalizeSummary({
+    ...summarizeSeries(metrics.tokenSeriesPost),
+    end: metrics.tokenSeriesPost[metrics.tokenSeriesPost.length - 1] || 0,
+  });
+  return {
+    turns: params.turns,
+    compact_count: 0,
+    total_elapsed_ms: metrics.elapsedMs,
+    lock_file_exists: metrics.lockExists,
+    pack_tokens: packTokensPost,
+    pack_tokens_pre: normalizeSummary({
+      ...summarizeSeries(metrics.tokenSeriesPre),
+      end: metrics.tokenSeriesPre[metrics.tokenSeriesPre.length - 1] || 0,
+    }),
+    pack_tokens_post: packTokensPost,
+    turn_time: normalizeSummary(summarizeSeries(metrics.turnTimes)),
+    pack_time: normalizeSummary(summarizeSeries(metrics.packTimes)),
+    pack_build_time: normalizeSummary(summarizeSeries(metrics.packBuildTimes)),
+    token_est_time: normalizeSummary(summarizeSeries(metrics.tokenEstTimes)),
+    compact_time: normalizeSummary({ avg: 0, p50: 0, p95: 0, max: 0, min: 0 }),
+    compact_check_time: normalizeSummary({ avg: 0, p50: 0, p95: 0, max: 0, min: 0 }),
+    compact_total_time: normalizeSummary({ avg: 0, p50: 0, p95: 0, max: 0, min: 0 }),
+    io_time: normalizeSummary(summarizeSeries(metrics.ioTimes)),
+    token_series_pre_compact: metrics.tokenSeriesPre,
+    token_series_post_compact: metrics.tokenSeriesPost,
+    token_series: metrics.tokenSeriesPost,
+  };
+}
+
+export async function runNaiveBenchmark(params, options = {}) {
+  const suffix = options.suffix || "";
+  const outPath = path.join(params.outDir, `bench_results_naive${suffix}.jsonl`);
+  await fs.mkdir(params.outDir, { recursive: true });
+
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "contextfs-bench-naive-"));
+  const config = mergeConfig({
+    autoInject: false,
+    autoCompact: false,
+    contextfsDir: ".naivefs",
+  });
+  const storage = new ContextFsStorage(workspace, config);
+  await storage.ensureInitialized();
+
+  const rng = createMulberry32(params.seed);
+  const lines = [];
+  const turnTimes = [];
+  const packTimes = [];
+  const packBuildTimes = [];
+  const tokenEstTimes = [];
+  const ioTimes = [];
+  const tokenSeriesPre = [];
+  const tokenSeriesPost = [];
+  const history = [];
+
+  const startedAt = performance.now();
+  try {
+    for (let turn = 1; turn <= params.turns; turn += 1) {
+      const turnStart = performance.now();
+      const event = generateTurn(turn, rng, params.avgChars, params.variance, params.seed);
+
+      const ioStart = performance.now();
+      await storage.appendHistory(event);
+      const ioMs = performance.now() - ioStart;
+
+      history.push(event);
+
+      const packBuildStart = performance.now();
+      const pack = buildNaivePack(history);
+      const packBuildMs = performance.now() - packBuildStart;
+
+      const tokenStart = performance.now();
+      const preTokens = estimateTokens(pack);
+      const tokenEstMs = performance.now() - tokenStart;
+
+      const postTokens = preTokens;
+      const packMs = packBuildMs + tokenEstMs;
+      const turnMs = performance.now() - turnStart;
+
+      lines.push(
+        JSON.stringify({
+          turn,
+          pack_build_time_ms: packBuildMs,
+          token_est_time_ms: tokenEstMs,
+          pack_time_ms: packMs,
+          compact_check_time_ms: 0,
+          compact_total_time_ms: 0,
+          compact_time_ms: 0,
+          io_time_ms: ioMs,
+          turn_time_ms: turnMs,
+          pack_est_tokens_pre_compact: preTokens,
+          pack_est_tokens_post_compact: postTokens,
+          pack_est_tokens: postTokens,
+          compacted: false,
+        }),
+      );
+
+      turnTimes.push(turnMs);
+      packTimes.push(packMs);
+      packBuildTimes.push(packBuildMs);
+      tokenEstTimes.push(tokenEstMs);
+      ioTimes.push(ioMs);
+      tokenSeriesPre.push(preTokens);
+      tokenSeriesPost.push(postTokens);
+    }
+
+    await fs.writeFile(outPath, `${lines.join("\n")}\n`, "utf8");
+
+    const lockPath = path.join(workspace, config.contextfsDir, ".lock");
+    let lockExists = false;
+    try {
+      await fs.access(lockPath);
+      lockExists = true;
+    } catch {
+      lockExists = false;
+    }
+
+    const elapsedMs = performance.now() - startedAt;
+    return {
+      label: "naive",
+      resultsPath: outPath,
+      summary: buildSummary(params, {
+        elapsedMs,
+        lockExists,
+        turnTimes,
+        packTimes,
+        packBuildTimes,
+        tokenEstTimes,
+        ioTimes,
+        tokenSeriesPre,
+        tokenSeriesPost,
+      }),
+    };
+  } finally {
+    await fs.rm(workspace, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const params = parseBenchArgs(process.argv.slice(2));
+  const result = await runNaiveBenchmark(params);
+  console.log("# Naive Benchmark Summary");
+  console.log(JSON.stringify({ params, naive: result.summary, out: result.resultsPath }, null, 2));
+}
+
+const isMain = process.argv[1] ? pathToFileURL(process.argv[1]).href === import.meta.url : false;
+
+if (isMain) {
+  main().catch((err) => {
+    console.error(err?.stack || String(err));
+    process.exitCode = 1;
+  });
+}

--- a/bench/lib/stats.mjs
+++ b/bench/lib/stats.mjs
@@ -1,0 +1,80 @@
+export function percentile(values, p) {
+  if (!values.length) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
+}
+
+export function median(values) {
+  if (!values.length) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[mid];
+  }
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export function summarizeSeries(values) {
+  if (!values.length) {
+    return { avg: 0, p50: 0, p95: 0, max: 0, min: 0 };
+  }
+  const sum = values.reduce((acc, n) => acc + n, 0);
+  return {
+    avg: sum / values.length,
+    p50: percentile(values, 50),
+    p95: percentile(values, 95),
+    max: Math.max(...values),
+    min: Math.min(...values),
+  };
+}
+
+export function linearSlope(values) {
+  if (values.length < 2) {
+    return 0;
+  }
+  const xMean = (values.length - 1) / 2;
+  const yMean = values.reduce((acc, v) => acc + v, 0) / values.length;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < values.length; i += 1) {
+    const x = i - xMean;
+    const y = values[i] - yMean;
+    num += x * y;
+    den += x * x;
+  }
+  return den === 0 ? 0 : num / den;
+}
+
+export function detectPlateauTurn(values, window = 120, slopeEpsilon = 0.5) {
+  if (values.length < window * 2) {
+    return -1;
+  }
+  for (let i = window; i < values.length; i += 1) {
+    const slice = values.slice(i - window, i);
+    const slope = linearSlope(slice);
+    const max = Math.max(...slice);
+    const min = Math.min(...slice);
+    const spread = max - min;
+    if (Math.abs(slope) <= slopeEpsilon && spread <= Math.max(40, max * 0.2)) {
+      return i + 1;
+    }
+  }
+  return -1;
+}
+
+export function toFixed3(value) {
+  return Number(value.toFixed(3));
+}
+
+export function normalizeSummary(summary) {
+  const out = {};
+  for (const [key, value] of Object.entries(summary)) {
+    out[key] = typeof value === "number" ? toFixed3(value) : value;
+  }
+  return out;
+}

--- a/bench/lib/synth.mjs
+++ b/bench/lib/synth.mjs
@@ -1,0 +1,123 @@
+import path from "node:path";
+
+const DEFAULTS = {
+  turns: 3000,
+  orders: 1,
+  avgChars: 400,
+  variance: 0.6,
+  seed: 42,
+  threshold: null,
+  recentN: null,
+  outDir: process.cwd(),
+};
+
+function toNumber(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function parseBenchArgs(argv = process.argv.slice(2), overrides = {}) {
+  const map = { ...DEFAULTS, ...overrides };
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key.startsWith("--")) {
+      continue;
+    }
+    if (key === "--turns") {
+      map.turns = toNumber(value, map.turns);
+      i += 1;
+      continue;
+    }
+    if (key === "--avgChars") {
+      map.avgChars = toNumber(value, map.avgChars);
+      i += 1;
+      continue;
+    }
+    if (key === "--orders") {
+      map.orders = toNumber(value, map.orders);
+      i += 1;
+      continue;
+    }
+    if (key === "--variance") {
+      map.variance = toNumber(value, map.variance);
+      i += 1;
+      continue;
+    }
+    if (key === "--seed") {
+      map.seed = toNumber(value, map.seed);
+      i += 1;
+      continue;
+    }
+    if (key === "--threshold") {
+      map.threshold = toNumber(value, map.threshold);
+      i += 1;
+      continue;
+    }
+    if (key === "--recentN") {
+      map.recentN = toNumber(value, map.recentN);
+      i += 1;
+      continue;
+    }
+    if (key === "--outDir") {
+      map.outDir = path.resolve(value || map.outDir);
+      i += 1;
+    }
+  }
+
+  map.turns = Math.max(1, Math.floor(map.turns));
+  map.orders = Math.max(1, Math.min(2, Math.floor(map.orders)));
+  map.avgChars = Math.max(32, Math.floor(map.avgChars));
+  map.variance = Math.max(0, Math.min(2, Number(map.variance)));
+  map.seed = Math.floor(map.seed);
+  map.threshold = map.threshold == null ? null : Math.max(256, Math.floor(map.threshold));
+  map.recentN = map.recentN == null ? null : Math.max(1, Math.floor(map.recentN));
+  map.outDir = path.resolve(map.outDir || process.cwd());
+  return map;
+}
+
+export function createMulberry32(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function deterministicTimestamp(seed, index) {
+  const base = Date.UTC(2025, 0, 1, 0, 0, 0, 0);
+  const seedOffsetMs = (Math.abs(Math.floor(seed)) % 86400) * 1000;
+  return new Date(base + seedOffsetMs + Math.max(0, index) * 1000).toISOString();
+}
+
+function makeText(targetChars, turn, role) {
+  const chunks = [
+    `turn=${turn}`,
+    `role=${role}`,
+    "topic=contextfs-benchmark",
+    "payload=",
+  ];
+  const base = `${chunks.join(" ")} `;
+  const unit = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega ";
+  let text = base;
+  while (text.length < targetChars) {
+    text += unit;
+  }
+  return text.slice(0, targetChars);
+}
+
+export function generateTurn(index, rng, avgChars, variance, seed = 0) {
+  const role = index % 2 === 1 ? "user" : "assistant";
+  const swing = (rng() * 2 - 1) * variance;
+  const targetChars = Math.max(16, Math.floor(avgChars * (1 + swing)));
+  const text = makeText(targetChars, index, role);
+  return {
+    role,
+    text,
+    chars: text.length,
+    ts: deterministicTimestamp(seed, index),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "scripts": {
     "test:contextfs:unit": "npm test --prefix .opencode/plugins/contextfs",
-    "test:contextfs:regression": "node scripts/regression-contextfs.mjs"
+    "test:contextfs:regression": "node scripts/regression-contextfs.mjs",
+    "bench:e2e": "node bench/bench_e2e.mjs",
+    "bench:naive": "node bench/bench_naive.mjs",
+    "bench": "node bench/bench.mjs"
   }
 }


### PR DESCRIPTION
…imal tests

- Add bench/bench_e2e.mjs (ContextFS) and bench/bench_naive.mjs (baseline)
- Add bench/bench.mjs orchestrator with --orders 1/2 and median comparison
- Add bench/lib/synth.mjs (deterministic workload) and stats.mjs (metrics)
- Add bench/bench.test.mjs with nested schema parity and timing sanity tests
- Update package.json with bench:* scripts
- Update README.md with concise benchmark section (metrics, commands, results)
- Update AGENTS.md with current build/test/benchmark commands and style guidelines

Verified:
- node --test bench/bench.test.mjs (4/4 pass)
- npm run bench -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42 --orders 2