### PR TITLE
refactor: remove legacy decisions/tasks artifacts from contextfs

### DIFF
--- a/.opencode/plugins/contextfs/README.md
+++ b/.opencode/plugins/contextfs/README.md
@@ -4,11 +4,13 @@ Small, non-invasive OpenCode plugin to keep long sessions stable.
 
 ## Core Features
 
-- **Context Management**: Maintains 4 types of files in `.contextfs/`
-  - `manifest.md` - Project structure
+- **Context Management**: Maintains core files in `.contextfs/`
+  - `manifest.md` - Project structure/status
   - `pins.md` - Key constraints/pins
   - `summary.md` - Rolling summary of compressed history
   - `history.ndjson` - Recent N turns (NDJSON format)
+  - `history.archive.ndjson` - Archived compacted turns
+  - `history.archive.index.ndjson` - Archive retrieval index
 
 - **Context Pack**: Builds fixed pack each turn
   - PINS (max 20 items)

--- a/.opencode/plugins/contextfs/src/commands.mjs
+++ b/.opencode/plugins/contextfs/src/commands.mjs
@@ -267,10 +267,6 @@ function safeFileName(name) {
     "pins.md",
     "summary",
     "summary.md",
-    "decisions",
-    "decisions.md",
-    "tasks/current.md",
-    "current",
     "history",
     "history.ndjson",
     "history.archive.ndjson",
@@ -278,9 +274,6 @@ function safeFileName(name) {
   ]);
   if (!allowed.has(target)) {
     return null;
-  }
-  if (target === "current" || target === "tasks/current.md") {
-    return map.tasks;
   }
   if (target.endsWith(".md") || target.endsWith(".ndjson")) {
     return target;
@@ -385,7 +378,7 @@ export async function runCtxCommand(commandLine, storage, config) {
   if (cmd === "cat") {
     const target = safeFileName(args[0]);
     if (!target) {
-      return errorResult("unknown file. use manifest|pins|summary|decisions|tasks/current.md|history");
+      return errorResult("unknown file. use manifest|pins|summary|history");
     }
     const headIndex = args.indexOf("--head");
     const head = headIndex >= 0 ? toInt(args[headIndex + 1], 30) : null;

--- a/.opencode/plugins/contextfs/src/storage.mjs
+++ b/.opencode/plugins/contextfs/src/storage.mjs
@@ -5,8 +5,6 @@ const FILES = {
   manifest: "manifest.md",
   pins: "pins.md",
   summary: "summary.md",
-  decisions: "decisions.md",
-  tasks: path.join("tasks", "current.md"),
   history: "history.ndjson",
   historyArchive: "history.archive.ndjson",
   historyArchiveIndex: "history.archive.index.ndjson",
@@ -362,13 +360,10 @@ export class ContextFsStorage {
 
   async ensureInitialized() {
     await fs.mkdir(this.baseDir, { recursive: true });
-    await fs.mkdir(path.join(this.baseDir, "tasks"), { recursive: true });
 
     await this.ensureFile("manifest", this.defaultManifest());
     await this.ensureFile("pins", this.defaultPins());
     await this.ensureFile("summary", this.defaultSummary());
-    await this.ensureFile("decisions", this.defaultDecisions());
-    await this.ensureFile("tasks", this.defaultTask());
     await this.ensureFile("history", "");
     await this.ensureFile("historyArchive", "");
     await this.ensureFile("historyArchiveIndex", "");
@@ -775,8 +770,6 @@ export class ContextFsStorage {
       "## files",
       "- pins.md | key constraints and prohibitions | tags: pins,policy",
       "- summary.md | rolling compact summary | tags: memory,compact",
-      "- decisions.md | long-form decisions and rationale | tags: decision,log",
-      "- tasks/current.md | current task status | tags: task,short",
       "- history.ndjson | compactable turn history | tags: runtime,history",
       "- history.archive.ndjson | archived compacted turn history | tags: runtime,archive",
       "- history.archive.index.ndjson | archive retrieval index | tags: runtime,index",
@@ -793,7 +786,7 @@ export class ContextFsStorage {
   }
 
   defaultManifest() {
-    return "# ContextFS Manifest\n\n- updated: pending\n- revision: 0\n\n## files\n- pins.md\n- summary.md\n- decisions.md\n- tasks/current.md\n";
+    return "# ContextFS Manifest\n\n- updated: pending\n- revision: 0\n\n## files\n- pins.md\n- summary.md\n";
   }
 
   defaultPins() {
@@ -804,13 +797,6 @@ export class ContextFsStorage {
     return "# Rolling Summary\n\n- init: no summary yet.\n";
   }
 
-  defaultDecisions() {
-    return "# Decisions\n\n| Time | Decision | Reason |\n|---|---|---|\n";
-  }
-
-  defaultTask() {
-    return "# Current Task\n\n- status: idle\n";
-  }
 
   defaultState() {
     return {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ContextFS 是一个为 OpenCode 设计的轻量级上下文管理插件，解决
 
 | 文件 | 用途 |
 |------|------|
-| `manifest.md` | 项目结构和待办事项清单 |
+| `manifest.md` | 项目结构和状态清单 |
 | `pins.md` | 关键约束/规则的固定记忆 |
 | `summary.md` | 历史对话的滚动摘要（压缩后的旧历史） |
 | `history.ndjson` | 最近 N 轮对话的详细记录（hot 区） |


### PR DESCRIPTION
Keep runtime context files aligned with the current archive-first design so manifests and CLI help no longer reference files the storage layer does not manage.