### PR TITLE
feat: implement Token Cost Visibility and Layered Context Contract (L…

### DIFF
--- a/.opencode/plugins/contextfs/src/storage.mjs
+++ b/.opencode/plugins/contextfs/src/storage.mjs
@@ -381,7 +381,7 @@ export class ContextFsStorage {
     }
   }
 
-  async acquireLock(maxRetries = 20) {
+  async acquireLock(maxRetries = 80) {
     const staleMs = Math.max(1000, Number(this.config.lockStaleMs || 30000));
     for (let i = 0; i <= maxRetries; i += 1) {
       const stamp = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,9 @@ Use this as the quick-start reference for coding agents working in this repo.
 - Node.js project; plugin package is ESM (`"type": "module"`).
 - Runtime code is plain `.mjs`; no transpile/build step.
 - Test runner is Node built-in test (`node --test`).
-- Workspace includes both plugin runtime and benchmark tooling.
 
 ## 3) Cursor / Copilot Rule Files
-Checked and currently absent:
-- `.cursorrules`: not found
-- `.cursor/rules/`: not found
-- `.github/copilot-instructions.md`: not found
-If any are added later, treat them as higher-priority local instructions and update this file.
+No Cursor/Copilot rule files found (`.cursorrules`, `.cursor/rules/`, `.github/copilot-instructions.md`).
 
 ## 4) Install / Build / Lint / Test Commands
 ### Install
@@ -33,13 +28,12 @@ If any are added later, treat them as higher-priority local instructions and upd
 - Plugin-only install: `npm install --prefix .opencode/plugins/contextfs`
 
 ### Build
-- No `build` script in root `package.json`.
-- No compile pipeline for runtime modules.
+- No `build` script; runtime is plain `.mjs` ESM (no compile pipeline).
 
 ### Lint / Format
 - No lint/format scripts in root or plugin `package.json`.
 - No repo lint config detected (ESLint/Prettier/Biome).
-- Match existing style; do not introduce new tooling unless requested.
+- Match existing file style; do not introduce new tooling unless requested.
 
 ### Tests (full suites)
 - Plugin unit tests via root script: `npm run test:contextfs:unit`
@@ -47,18 +41,19 @@ If any are added later, treat them as higher-priority local instructions and upd
 - Regression suite: `npm run test:contextfs:regression`
 - Bench tests: `node --test ./bench/bench.test.mjs`
 
+Notes:
+- Plugin unit tests run with `--test-isolation=none` (see `.opencode/plugins/contextfs/package.json`). Preserve that when running tests directly.
+
 ### Tests (single test)
 Use Node test name filtering:
 - Plugin single test:
-  - `node --test --test-name-pattern="compacted turns remain retrievable via archive fallback" ./.opencode/plugins/contextfs/test/contextfs.test.mjs`
-- Plugin single test (another example):
-  - `node --test --test-name-pattern="ctx reindex preserves raw duplicate archive ids for get/search consistency" ./.opencode/plugins/contextfs/test/contextfs.test.mjs`
+  - `node --test --test-isolation=none --test-name-pattern="compacted turns remain retrievable via archive fallback" ./.opencode/plugins/contextfs/test/contextfs.test.mjs`
+- Plugin single test via npm (passes args through):
+  - `npm test --prefix .opencode/plugins/contextfs -- --test-name-pattern="estimateTokens is stable and monotonic"`
 - Bench single test:
   - `node --test --test-name-pattern="timing fields are sane in jsonl outputs" ./bench/bench.test.mjs`
 
 ### Bench runs
-- `npm run bench:e2e -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42`
-- `npm run bench:naive -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42`
 - `npm run bench -- --turns 3000 --avgChars 400 --variance 0.6 --seed 42 --orders 2`
 
 ## 5) ContextFS CLI Sanity Commands
@@ -69,19 +64,22 @@ Use Node test name filtering:
 - `node .opencode/plugins/contextfs/cli.mjs get H-abc12345 --head 1200`
 - `node .opencode/plugins/contextfs/cli.mjs reindex`
 
+Preferred interactive usage (OpenCode chat): `/ctx ...` (see `README.md`).
+
 ## 6) Code Style and Implementation Conventions
 ### Imports
 - Use ESM `import` syntax in `.mjs` and `.ts` files.
 - Use `node:` specifiers for built-ins (`node:fs/promises`, `node:path`, etc.).
 - Keep built-in imports above local imports.
 - Separate import groups with one blank line.
-- Use double quotes and semicolons.
+- Prefer double quotes.
 
 ### Formatting
 - Two-space indentation.
-- Semicolons enabled.
 - Prefer trailing commas in multiline literals/calls.
 - Favor small helpers and early returns over deep nesting.
+
+Note: semicolon usage is mixed across modules (some files omit them). Do not reformat unrelated lines; follow the surrounding file’s style.
 
 ### Naming
 - Variables/functions: `camelCase`.
@@ -94,6 +92,10 @@ Use Node test name filtering:
 - Validate and clamp numeric config boundaries in one place.
 - Keep retrieval/history row schemas explicit and stable (`id`, `ts`, `role`, `type`, `refs`, `text`).
 - In TypeScript bridge code, avoid `any` unless there is clear justification.
+
+CLI/JSON contracts to preserve:
+- `ctx search --json` / `ctx timeline --json` return stable L0 rows with `layer: "L0"`.
+- `ctx get --json` returns `layer: "L2"` and applies byte-budget trimming via `--head`.
 
 ### Async, I/O, and Concurrency
 - Use `async/await` consistently.
@@ -108,8 +110,12 @@ Use Node test name filtering:
 ### Error Handling
 - Throw explicit errors for hard failures.
 - Use narrow `try/finally` for lock cleanup and restoration flows.
-- Avoid silent failure paths; if ignoring malformed lines, keep behavior deliberate and bounded.
+- Avoid silent failure paths; if ignoring malformed lines, keep behavior deliberate and bounded (e.g., malformed NDJSON lines are tracked in `history.bad.ndjson`).
 - CLI should return structured errors and non-zero exit code on fatal failures.
+
+### Configuration
+- Default config and clamping live in `.opencode/plugins/contextfs/src/config.mjs`.
+- Override via `globalThis.CONTEXTFS_CONFIG = { ... }` (used by plugin) or set `CONTEXTFS_DEBUG=1` to enable debug logging.
 
 ### Output and UX Contracts
 - Keep CLI output line-oriented and stable.
@@ -134,10 +140,10 @@ Use Node test name filtering:
 
 ## 9) Repo Notes
 - `.contextfs/` contains runtime data and is ignored.
-- `docs/` is ignored in `.gitignore`; use `git add -f` only when docs must be committed.
+- `docs/` is ignored in `.gitignore`; only force-add it when you truly intend to commit docs.
 - For new commands/flags, update docs and tests in the same change.
 
 ## 10) Hand-off Checklist
 1. Verify commands against actual `package.json` scripts.
 2. Run relevant tests (full suite or targeted `--test-name-pattern`).
-3. Update `README.md` and this file when workflows or behavior change.
+3. Update `README.md`/`AGENTS.md` when user-visible behavior changes.

--- a/README.md
+++ b/README.md
@@ -48,14 +48,28 @@ cp -r <path-to-contextfs>/.opencode/plugins/contextfs .opencode/plugins/
 在 OpenCode 对话框直接输入：
 
 ```text
-/ctx search "lock timeout" --k 5
+/ctx search "lock timeout" --k 5 --scope all
 /ctx timeline H-abc12345 --before 3 --after 3
 /ctx get H-abc12345 --head 1200
+/ctx stats --json
 /ctx pin "不要修改核心架构"
 /ctx compact
 ```
 
 如果只是日常使用，优先使用 `/ctx ...`，不需要手动执行 Node 命令。
+
+## L0/L1/L2 分层（渐进式检索契约）
+
+ContextFS 把“检索与注入”分成三层，核心目的是省 token 且可追溯：
+
+- L0（Index / Recall）：超便宜的索引行，用来决定“要不要展开、展开哪个 ID”
+  - 对应：`/ctx search`、`/ctx timeline` 输出的摘要行（ID + 摘要）
+- L1（Overview / Navigation）：可预算的概览，用来做决策与保持任务连续性
+  - 对应：PINS / SUMMARY / MANIFEST，以及 pack 里的 `WORKSET_RECENT_TURNS`（导航预览，不是完整回放）
+- L2（Detail / Playback）：按需获取的完整细节
+  - 对应：`/ctx get <id>`
+
+完整契约见：`CONTEXT_LAYERS.md`
 
 ## 推荐使用方式
 
@@ -65,12 +79,20 @@ cp -r <path-to-contextfs>/.opencode/plugins/contextfs .opencode/plugins/
 
 这样可以显著减少 token 浪费，同时保持信息可追溯。
 
+### 输出与字段（对齐当前分支）
+
+- `ctx search` 支持 `--scope all|hot|archive` 控制检索范围；`search/timeline/get/stats` 支持 `--json` 输出结构化结果。
+- `ctx search --json` / `ctx timeline --json`：返回 `layer: "L0"`，每条结果是稳定的 L0 行（`id/ts/type/summary/source/layer`），并可能包含 `score`、`expand`（提示展开 `timeline/get` 的默认窗口与粗略 token 量级）。
+- `ctx get --json`：返回 `layer: "L2"`，包含 `record`（完整记录，默认按 `--head` 做裁剪）与 `source`（hot|archive）。
+- `ctx stats`：文本输出会额外打印 `pack_breakdown_tokens(est)`；`--json` 会包含 `pack_breakdown`（各 section 的 token 估算）。
+
 ## 目录说明（用户视角）
 
 `.contextfs/` 下最常见的文件：
 
 - `pins.md`: 关键约束
 - `summary.md`: 历史压缩摘要
+- `state.json`: 运行时状态（如 lastSearchIndex、计数器、上次检索信息）
 - `history.ndjson`: 近期严格问答对（用户原问题 + 助手最终回答）
 - `history.archive.ndjson`: 归档历史
 - `history.archive.index.ndjson`: 归档检索索引
@@ -81,7 +103,7 @@ cp -r <path-to-contextfs>/.opencode/plugins/contextfs .opencode/plugins/
 不会。默认只记录用户原问题和助手最终回答。
 
 ### Q2: 历史被压缩后还能找回来吗？
-可以。归档历史仍可通过 `search` / `timeline` / `get` 检索和回放。
+可以。归档历史仍可通过 `search` / `timeline` / `get` 检索和回放（`get` 会自动做 archive fallback；`search/timeline` 依赖 archive index）。如果 index 异常，可运行 `/ctx reindex` 重建。
 
 ### Q3: 会影响现有项目代码吗？
 不会。插件主要读写 `.contextfs/` 和插件目录，不会侵入业务代码。


### PR DESCRIPTION
…0/L1/L2)

- Feature 1: Token Cost Visibility
  - Add pack_breakdown to ctx stats (pins_tokens, summary_tokens, etc.)
  - Add expansion guidance to ctx search (expand.timeline/get with tokens_est)
  - Add layer markers to JSON outputs (layer: L0 for search/timeline, L2 for get)

- Feature 4: Layered Context Contract
  - Implement stable L0 row shape (id/ts/type/summary/source/layer)
  - Add source field to retrieval index and workset preview
  - Enforce bounded single-line summaries in L0 rows
  - Pack composition rules: L1 + bounded L0, never L2 by default

- Lock retry increase: storage.acquireLock maxRetries 20 -> 80
- Add comprehensive tests for new features
- Update AGENTS.md and README.md with L0/L1/L2 documentation